### PR TITLE
Update metaApiSynchronizationExample.js

### DIFF
--- a/examples/mt5/metaApiSynchronizationExample.js
+++ b/examples/mt5/metaApiSynchronizationExample.js
@@ -60,14 +60,14 @@ async function testMetaApiSynchronization() {
     // access history storage
     const historyStorage = connection.historyStorage;
     console.log('deals:', historyStorage.deals.slice(-5));
-    console.log('deals with id=1:', historyStorage.dealsByTicket(1));
-    console.log('deals with positionId=1:', historyStorage.dealsByPosition(1));
-    console.log('deals for the last day:', historyStorage.dealsByTimeRange(new Date(Date.now() - 24 * 60 * 60 * 1000),
+    console.log('deals with id=1:', historyStorage.getDealsByTicket(1));
+    console.log('deals with positionId=1:', historyStorage.getDealsByPosition(1));
+    console.log('deals for the last day:', historyStorage.getDealsByTimeRange(new Date(Date.now() - 24 * 60 * 60 * 1000),
       new Date());
     console.log('history orders:', historyStorage.historyOrders.slice(-5));
-    console.log('history orders with id=1:', historyStorage.historyOrdersByTicket(1));
-    console.log('history orders with positionId=1:', historyStorage.historyOrdersByPosition(1));
-    console.log('history orders for the last day:', historyStorage.historyOrdersByTimeRange(
+    console.log('history orders with id=1:', historyStorage.getHistoryOrdersByTicket(1));
+    console.log('history orders with positionId=1:', historyStorage.getHistoryOrdersByPosition(1));
+    console.log('history orders for the last day:', historyStorage.getHistoryOrdersByTimeRange(
       new Date(Date.now() - 24 * 60 * 60 * 1000), new Date());
 
     // trade


### PR DESCRIPTION
Updated function names of historyStorage - prepended `get`

Since there is no "metaapi.cloud-sdk": "^18.0.0" release, I needed to build it and add the whole content of  `dist` directory to the `examples` directory  `node_modules/metaapi.cloud-sdk`.