### PR TITLE
update binary-search-tree

### DIFF
--- a/lib/metaApi/memoryHistoryStorage.es6
+++ b/lib/metaApi/memoryHistoryStorage.es6
@@ -2,7 +2,7 @@
 
 import HistoryStorage from './historyStorage';
 import HistoryDatabase from './historyDatabase/index';
-import {AVLTree} from 'binary-search-tree';
+import {AVLTree} from '@verluci/binary-search-tree';
 import LoggerManager from '../logger';
 
 /**

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   "dependencies": {
     "@log4js-node/log4js-api": "~1.0.2",
     "babel-runtime": "~6.26.0",
-    "binary-search-tree": "~0.2.6",
+    "@verluci/binary-search-tree": "~0.3.0",
     "crypto-js": "~4.1.1",
     "dotenv": "~8.2.0",
     "fs-extra": "~9.0.1",


### PR DESCRIPTION
I've forked binary-search-tree to fix the dependency on a dangerously outdated underscore. This PR uses this new version of binary-search-tree